### PR TITLE
Data Quality API

### DIFF
--- a/btrdbextras/dq.py
+++ b/btrdbextras/dq.py
@@ -1,12 +1,11 @@
 import re
+import warnings
 from tabulate import tabulate
 
 import btrdb
 from btrdb.stream import StreamSet, Stream
 from btrdb.utils.general import pointwidth
 from btrdb.utils.timez import ns_delta, to_nanoseconds
-from tabulate import tabulate
-import warnings
 
 KNOWN_DISTILLER_TYPES = ["repeats", "duplicate-times", "zeros"]
 

--- a/btrdbextras/dq.py
+++ b/btrdbextras/dq.py
@@ -1,0 +1,259 @@
+import re
+import btrdb
+from btrdb.stream import StreamSet, Stream
+from btrdb.utils.general import pointwidth
+from btrdb.utils.timez import ns_delta, to_nanoseconds
+
+KNOWN_DISTILLER_TYPES = ["repeats", "duplicates", "zeros"]
+
+class Distillate(Stream):
+    """
+    Subsets a Stream object and allows for identfication of data quality events
+
+    Parameters
+    ----------
+    btrdb : BTrDB
+        A reference to the BTrDB object connecting this stream back to the
+		physical server.
+    uuid : UUID
+        The unique UUID identifier for this stream.
+    """
+    def __init__(self, btrdb, uu):
+        # gives all same attrs/methods as Stream
+        super().__init__(btrdb, uu)
+
+        # NOTE: this involves determining distiller type based on the distillate 
+        # stream name, so we will need to be careful how we name distillates
+        types = re.findall(r"(?=("+'|'.join(KNOWN_DISTILLER_TYPES)+r"))", self.name)
+        if len(types) == 0:
+            raise Exception(f"unknown distiller type. Must be one of [{','.join(KNOWN_DISTILLERS)}]")
+        if len(types) > 1:
+            raise Exception(f"ambiguous distiller name. contains references to [{', '.join(types)}]")            
+        self.type = types[0]
+
+    def contains_event(self, start=None, end=None, depth=30):
+        """
+        Tells whether a distillate stream contains an event, which is denoted by 1 values
+
+        Parameters
+        ----------
+        start: (optional) datetime, datetime64, float, str
+            start time of period to search for events
+        end: (optional) datetime, datetime64, float, str
+            end time of period to search for events
+        depth: (optional) int
+            The precision of the window duration as a power of 2 in nanoseconds.
+            e.g 30 would make the window duration accurate to roughly 1 second
+        
+        Returns
+        -------
+        bool
+            Returns bool indicating whether or not the distillate stream contains an event
+        """
+        start = to_nanoseconds(start) if start else self.earliest()[0].time
+        end = to_nanoseconds(end) if end else self.latest()[0].time + 1
+        width = end - start
+        windows, _ = zip(*self.windows(start, end, width, depth))
+        return any(w.max >= 1 for w in windows)
+    
+    def __repr__(self):
+        return f"Distillate collection={self.collection}, name={self.name}, type={self.type}, parent={self.parent}"
+
+class DQStream(Stream):
+    """
+    Subsets StreamSet object. Contains an original stream along with its
+    distillate Streams
+    """
+    def __init__(self, stream):
+        # gives all same attrs/methods as Stream
+        super().__init__(stream._btrdb, stream.uuid)
+        self._distillates = self._get_distillates()
+		
+	def _get_distillates(self):
+        """
+        Finds distillate streams for each of the underlying source streams
+
+        Returns
+        -------
+        list[Distillates]
+            List of distillate streams
+        """
+        distillates = [
+            Distillate(stream._btrdb, stream.uuid)
+            for stream in self._btrdb.streams_in_collection(annotations={"source_uuid": str(self.uuid)})
+        ]
+        if len(distillates) < 1:
+            raise Exception("Could not find any distillates for the provided streams")
+        return distillates
+		
+    @property
+    def distillates(self):
+        """
+        Returns list of distillate streams
+        """
+        return self._distillates
+    
+    def describe(self):
+        """
+        Outputs table describing metadata of distillate streams
+        """
+        raise NotImplementedError
+    
+    def contains_any_event(self, start=None, end=None, depth=30):
+        """
+        Indicates whether this group of streams contains any data quality events
+
+        Parameters
+        ----------
+        start: (optional) datetime, datetime64, float, str
+            start time of period to search for events
+        end: (optional) datetime, datetime64, float, str
+            end time of period to search for events
+        depth: (optional) int
+            The precision of the window duration as a power of 2 in nanoseconds.
+            e.g 30 would make the window duration accurate to roughly 1 second
+        
+        Returns
+        -------
+        bool
+            Returns bool indicating whether or not any of the underlying streams
+            contain any event
+        """
+        for distillate in self._distillates:
+            if distillate.contains_event(start=start, end=end, depth=depth):
+                return True
+        return False
+
+    def contains_event(self, distil_type, start=None, end=None, depth=30):
+        """
+        Indicates whether this group of streams contains a specific data quality event
+
+        Parameters
+        ----------
+        distil_type: str
+            The type of event to search for. Must be one of KNOWN_DISTILLER_TYPES
+        start: (optional) datetime, datetime64, float, str
+            start time of period to search for events
+        end: (optional) datetime, datetime64, float, str
+            end time of period to search for events
+        depth: (optional) int
+            The precision of the window duration as a power of 2 in nanoseconds.
+            e.g 30 would make the window duration accurate to roughly 1 second
+        
+        Returns
+        -------
+        bool
+            Returns bool indicating whether or not any of the underlying streams contain
+            a certain event
+        """
+        distillate = self[distil_type]
+        return distillate.contains_event(start=start, end=end, depth=depth)
+    
+    def __getitem__(self, item):
+        for distillate in self._distillates:
+            if distillate.type == item:
+                return distillate
+        raise KeyError(f"Distillate with type '{item}' not found")
+		
+class DQStreamSet(StreamSet):
+    """
+    Subsets a StreamSet object
+
+    Parameters
+    ----------
+    streams: list
+        list[btrdb.stream.Stream]
+    """
+    def __init__(self, streams):		
+        dq_streams = []
+        for stream in streams:
+            if not isinstance(stream, DQStream):
+                stream = DQStream(stream)
+            dq_streams.append(stream)
+        
+        # gets everything that a StreamSet has
+		super().__init__(dq_streams)
+        # self._conn = streams[0]._btrdb
+        # self._distillates = self._get_distillates()
+    
+    @property
+    def distillates(self):
+        """
+        Returns list of distillate streams
+        """
+        return [
+		    stream._distillates
+			for stream in self._streams
+		]        
+    
+    def describe(self):
+        """
+        Outputs table describing metadata of distillate streams
+        """
+        raise NotImplementedError
+    
+    def contains_any_event(self, start=None, end=None, depth=30):
+        """
+        Indicates whether this group of streams contains any data quality events
+
+        Parameters
+        ----------
+        start: (optional) datetime, datetime64, float, str
+            start time of period to search for events
+        end: (optional) datetime, datetime64, float, str
+            end time of period to search for events
+        depth: (optional) int
+            The precision of the window duration as a power of 2 in nanoseconds.
+            e.g 30 would make the window duration accurate to roughly 1 second
+        
+        Returns
+        -------
+        dict
+            Returns bool indicating whether or not any of the underlying streams
+            contain any event
+        """
+        for stream in self._streams:
+            if stream.contains_any_event(start=start, end=end, depth=depth):
+                return True
+        return False
+
+    def contains_event(self, distil_type, start=None, end=None, depth=30):
+        """
+        Indicates whether this group of streams contains a specific data quality event
+
+        Parameters
+        ----------
+        distil_type: str
+            The type of event to search for. Must be one of KNOWN_DISTILLER_TYPES
+        start: (optional) datetime, datetime64, float, str
+            start time of period to search for events
+        end: (optional) datetime, datetime64, float, str
+            end time of period to search for events
+        depth: (optional) int
+            The precision of the window duration as a power of 2 in nanoseconds.
+            e.g 30 would make the window duration accurate to roughly 1 second
+        
+        Returns
+        -------
+        bool
+            Returns bool indicating whether or not any of the underlying streams contain
+            a certain event
+        """
+        for stream in self._streams:
+            try:
+                stream.contains_event(distil_type, start=start, end=end, depth=depth)
+            except KeyError:
+                continue
+
+        distillate = self[distil_type]
+        return distillate.contains_event(start=start, end=end, depth=depth)
+    
+    def __getitem__(self, index):
+		# TODO: this needs to get a DQStream by index
+
+if __name__ == "__main__":
+    db = btrdb.connect(profile="d2")
+    stream = db.stream_from_uuid("9464f51f-e05a-5db1-a965-3c339f748081")
+    dq = DQStreamSet([stream])
+    print(dq.distillates)
+    print(dq.contains_event("zeros", start="2021-07-16 20:00:00.00", end="2021-07-16 23:00:00.00"))

--- a/btrdbextras/dq.py
+++ b/btrdbextras/dq.py
@@ -54,8 +54,8 @@ class Distillate(Stream):
         bool
             Returns bool indicating whether or not the distillate stream contains an event
         """
-        start = to_nanoseconds(start) if start else self.earliest()[0].time
-        end = to_nanoseconds(end) if end else self.latest()[0].time + 1
+        start = to_nanoseconds(start) or self.earliest()[0].time
+        end = to_nanoseconds(end) or self.latest()[0].time + 1
         width = end - start
         windows, _ = zip(*self.windows(start, end, width, depth))
         return any(w.max >= 1 for w in windows)

--- a/btrdbextras/dq.py
+++ b/btrdbextras/dq.py
@@ -249,7 +249,20 @@ class DQStreamSet(StreamSet):
         return distillate.contains_event(start=start, end=end, depth=depth)
     
     def __getitem__(self, index):
-		# TODO: this needs to get a DQStream by index
+		"""
+        Returns the DQStream contained at a given index within the set
+
+        Parameters
+        ----------
+        index: int
+            The index of the desired stream.
+
+        Returns
+        -------
+        DQStream
+            The DQStream stored in this object at the given index
+        """
+        return self._streams[index]
 
 if __name__ == "__main__":
     db = btrdb.connect(profile="d2")

--- a/btrdbextras/dq.py
+++ b/btrdbextras/dq.py
@@ -56,6 +56,9 @@ class Distillate(Stream):
         start = to_nanoseconds(start) or self.earliest()[0].time
         # adding 1 to end time because end is exclusive in windows()
         end = to_nanoseconds(end) or self.latest()[0].time + 1
+        # There's no event if there's no data
+        if start is None and end is None:
+            return False
         width = end - start
         windows, _ = zip(*self.windows(start, end, width, depth))
         return any(w.max >= 1 for w in windows)

--- a/btrdbextras/dq.py
+++ b/btrdbextras/dq.py
@@ -280,10 +280,9 @@ class DQStreamSet(StreamSet):
             Returns bool indicating whether or not any of the underlying streams
             contain any event
         """
-        for stream in self._streams:
-            if stream.contains_any_event(start=start, end=end, depth=depth):
-                return True
-        return False
+        return {
+            str(stream.uuid): stream.contains_any_event(start=start, end=end, depth=depth)
+        }
 
     def contains_event(self, distil_type, start=None, end=None, depth=30):
         """
@@ -303,18 +302,20 @@ class DQStreamSet(StreamSet):
         
         Returns
         -------
-        bool
+        dict[str, bool]
             Returns bool indicating whether or not any of the underlying streams contain
             a certain event
         """
+        out = {}
         for stream in self._streams:
             try:
-                stream.contains_event(distil_type, start=start, end=end, depth=depth)
+                contains = stream.contains_event(distil_type, start=start, end=end, depth=depth)
             except KeyError:
-                continue
-
-        distillate = self[distil_type]
-        return distillate.contains_event(start=start, end=end, depth=depth)
+                # NOTE: this might be a bad idea. How to represent streams that do not have this 
+                # distillate stream?
+                contains = None
+            out[str(stream.uuid)] = contains
+        return out
     
     def __getitem__(self, index):
         """
@@ -338,4 +339,5 @@ if __name__ == "__main__":
     stream1 = db.stream_from_uuid("9464f51f-e05a-5db1-a965-3c339f748081")
     dq = DQStreamSet([stream1, stream2])
     print(dq.distillates)
-    print(dq.describe())
+    # print(dq.describe())
+    # print(dq.contains_event("zeros", start="2021-07-16 20:00:00.00", end="2021-07-16 23:00:00.00"))

--- a/notebooks/dq_demo.ipynb
+++ b/notebooks/dq_demo.ipynb
@@ -1,0 +1,441 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e098fb88",
+   "metadata": {},
+   "source": [
+    "# Data Quality API\n",
+    "The purpose of this notebook is to demonstrate how to use the Data Quality API to access a BTrDB Stream's distillates and identify data quality issues"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b9fd9b87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import btrdb\n",
+    "from btrdbextras.dq import DQStream, DQStreamSet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "41ca35c9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'majorVersion': 5, 'build': '5.11.133', 'proxy': {'proxyEndpoints': []}}"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# this is a temporary test cluster\n",
+    "db = btrdb.connect(profile=\"d2\")\n",
+    "db.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a2321a8",
+   "metadata": {},
+   "source": [
+    "First we will see how to work with a single BTrDB Stream. `DQStream` subsets `Stream`, and can be instantiated by simply passing in a BTrDB `Stream` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a2b466a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DQStream collection=distiltest/a574-5a32-518b-b4e9-c9c86144107a, name=rand\n"
+     ]
+    }
+   ],
+   "source": [
+    "stream = db.stream_from_uuid(\"9464f51f-e05a-5db1-a965-3c339f748081\")\n",
+    "dq = DQStream(stream)\n",
+    "print(dq)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88454b01",
+   "metadata": {},
+   "source": [
+    "`DQStream` has all of the same attributes and methods as `Stream`, but it has an additional attribute `distillates`, which refers to a list of all of the distillate streams that have been derived from this source stream. We can use these distillates to identify specific data quality concerns."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46f73253",
+   "metadata": {},
+   "source": [
+    "## Detecting Events\n",
+    "We can use the `DQStream` to identify if the original `Stream` contains data quality issues. There are two methods for this: `contains_any_event()`, which reports if there are _any_ data quality concerns within the stream, as well as `contains_event()`, which reports if there is a specific data quality issue based on a user provided flag. Users can use the `list_distillates()` method to see which distillates are available"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a7abb3bd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead>\n",
+       "<tr><th>uuid       </th><th>collection                                 </th><th>name  </th><th>repeats  </th><th>duplicate-times  </th><th>zeros  </th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "<tr><td>9464f51f...</td><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>x        </td><td>✓                </td><td>✓      </td></tr>\n",
+       "</tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "'<table>\\n<thead>\\n<tr><th>uuid       </th><th>collection                                 </th><th>name  </th><th>repeats  </th><th>duplicate-times  </th><th>zeros  </th></tr>\\n</thead>\\n<tbody>\\n<tr><td>9464f51f...</td><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>x        </td><td>✓                </td><td>✓      </td></tr>\\n</tbody>\\n</table>'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# see which distillates are available\n",
+    "dq.list_distillates(notebook=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cae5a7e",
+   "metadata": {},
+   "source": [
+    "According to the table, this stream has `zeros` and `duplicate-times` distillates available, so let's see if we can find any events:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4ebe2867",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dq.contains_any_event()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f849be7c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dq.contains_event(\"zeros\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52be22ea",
+   "metadata": {},
+   "source": [
+    "It looks like this stream contains some zero values.\n",
+    "\n",
+    "We can also narrow our search to a specific time limit. You can see in the following example that this stream does not contain any zero values on July 16th:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9627bb87",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "start = \"2021-07-16 00:00:00.00\"\n",
+    "end = \"2021-07-17 00:00:00.00\"\n",
+    "dq.contains_event(\"zeros\", start=start, end=end)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1c5477d",
+   "metadata": {},
+   "source": [
+    "## Working with StreamSets\n",
+    "The API can also work with `StreamSets`. Similar to `StreamSet`, `DQStreamSet` is just a lightweight wrapper around a list of `DQStreams`. It can be instantiated by providing a list of `Streams`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "845f3d91",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/michael.chestnut/projects/btrdbextras/btrdbextras/dq.py:92: UserWarning: Could not find distillates for stream 077d6745-e3ae-5795-b22d-1eb067abb360\n",
+      "  warnings.warn(f\"Could not find distillates for stream {str(self.uuid)}\")\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<DQStreamSet (2 streams)>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stream1 = db.stream_from_uuid(\"9464f51f-e05a-5db1-a965-3c339f748081\")\n",
+    "stream2 = db.stream_from_uuid(\"077d6745-e3ae-5795-b22d-1eb067abb360\")\n",
+    "dqss = DQStreamSet([stream1, stream2])\n",
+    "dqss"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4683eab",
+   "metadata": {},
+   "source": [
+    "`DQStreamSet` has a `describe()` method that allows us to see metadata of the underlying `Streams`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1acbaad5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead>\n",
+       "<tr><th>Collection                                 </th><th>Name  </th><th>Unit  </th><th>UUID       </th><th style=\"text-align: right;\">  Version</th><th>Available Data Quality Info  </th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "<tr><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>rand  </td><td>9464f51f...</td><td style=\"text-align: right;\">     1072</td><td>zeros, duplicate-times       </td></tr>\n",
+       "<tr><td>distiltest/f0bd-d75b-582b-b8e9-ac9cc9401755</td><td>rand  </td><td>rand  </td><td>077d6745...</td><td style=\"text-align: right;\">     1072</td><td>N/A                          </td></tr>\n",
+       "</tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "'<table>\\n<thead>\\n<tr><th>Collection                                 </th><th>Name  </th><th>Unit  </th><th>UUID       </th><th style=\"text-align: right;\">  Version</th><th>Available Data Quality Info  </th></tr>\\n</thead>\\n<tbody>\\n<tr><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>rand  </td><td>9464f51f...</td><td style=\"text-align: right;\">     1072</td><td>zeros, duplicate-times       </td></tr>\\n<tr><td>distiltest/f0bd-d75b-582b-b8e9-ac9cc9401755</td><td>rand  </td><td>rand  </td><td>077d6745...</td><td style=\"text-align: right;\">     1072</td><td>N/A                          </td></tr>\\n</tbody>\\n</table>'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dqss.describe(notebook=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1b62fa3",
+   "metadata": {},
+   "source": [
+    "We can also peak at the underlying `Streams` and see which distillates they have available. Note that the second `Stream` does not have any distillates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "72d86d4b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead>\n",
+       "<tr><th>uuid       </th><th>collection                                 </th><th>name  </th><th>repeats  </th><th>duplicate-times  </th><th>zeros  </th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "<tr><td>9464f51f...</td><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>x        </td><td>✓                </td><td>✓      </td></tr>\n",
+       "<tr><td>077d6745...</td><td>distiltest/f0bd-d75b-582b-b8e9-ac9cc9401755</td><td>rand  </td><td>x        </td><td>x                </td><td>x      </td></tr>\n",
+       "</tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "'<table>\\n<thead>\\n<tr><th>uuid       </th><th>collection                                 </th><th>name  </th><th>repeats  </th><th>duplicate-times  </th><th>zeros  </th></tr>\\n</thead>\\n<tbody>\\n<tr><td>9464f51f...</td><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>x        </td><td>✓                </td><td>✓      </td></tr>\\n<tr><td>077d6745...</td><td>distiltest/f0bd-d75b-582b-b8e9-ac9cc9401755</td><td>rand  </td><td>x        </td><td>x                </td><td>x      </td></tr>\\n</tbody>\\n</table>'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dqss.list_distillates(notebook=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cbdba9c",
+   "metadata": {},
+   "source": [
+    "We can also see if the `Streams` within a `DQStreamSet` contain any events. The output of these methods is a `dict` with each `Stream` UUID as the key and a bool value indicating whether an event was found. Note that `None` will be returned as the value if the `DQStream` does not contain a certain distillate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "672d6a78",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'9464f51f-e05a-5db1-a965-3c339f748081': True,\n",
+       " '077d6745-e3ae-5795-b22d-1eb067abb360': None}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dqss.contains_any_event()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3f9bf9b3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'9464f51f-e05a-5db1-a965-3c339f748081': True,\n",
+       " '077d6745-e3ae-5795-b22d-1eb067abb360': None}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dqss.contains_event(\"duplicate-times\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ffe929fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'9464f51f-e05a-5db1-a965-3c339f748081': True,\n",
+       " '077d6745-e3ae-5795-b22d-1eb067abb360': None}"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dqss.contains_event(\"zeros\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbee33c1",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "* distillates will need to follow a certain naming convention for this to work properly.\n",
+    "* distillers will need to put `source_uuid` annotation in output streams so they can be correctly matched with their source streams."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af8c65e3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/dq_demo.ipynb
+++ b/notebooks/dq_demo.ipynb
@@ -29,7 +29,7 @@
     {
      "data": {
       "text/plain": [
-       "{'majorVersion': 5, 'build': '5.11.133', 'proxy': {'proxyEndpoints': []}}"
+       "{'majorVersion': 5, 'build': '5.11.137', 'proxy': {'proxyEndpoints': []}}"
       ]
      },
      "execution_count": 2,
@@ -38,8 +38,7 @@
     }
    ],
    "source": [
-    "# this is a temporary test cluster\n",
-    "db = btrdb.connect(profile=\"d2\")\n",
+    "db = btrdb.connect(profile=\"ni4ai\")\n",
     "db.info()"
    ]
   },
@@ -53,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "a2b466a9",
    "metadata": {},
    "outputs": [
@@ -61,12 +60,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DQStream collection=distiltest/a574-5a32-518b-b4e9-c9c86144107a, name=rand\n"
+      "DQStream collection=monitoring/generator1, name=PhA_Cang\n"
      ]
     }
    ],
    "source": [
-    "stream = db.stream_from_uuid(\"9464f51f-e05a-5db1-a965-3c339f748081\")\n",
+    "stream = db.stream_from_uuid(\"4f8a9730-80e6-4378-948d-cb64a277f8f3\")\n",
     "dq = DQStream(stream)\n",
     "print(dq)"
    ]
@@ -85,39 +84,34 @@
    "metadata": {},
    "source": [
     "## Detecting Events\n",
-    "We can use the `DQStream` to identify if the original `Stream` contains data quality issues. There are two methods for this: `contains_any_event()`, which reports if there are _any_ data quality concerns within the stream, as well as `contains_event()`, which reports if there is a specific data quality issue based on a user provided flag. Users can use the `list_distillates()` method to see which distillates are available:"
+    "We can use the `DQStream` to identify if the original `Stream` contains data quality issues. There are two methods for this: `contains_any_issue()`, which reports if there are _any_ data quality concerns within the stream, as well as `contains_issue()`, which reports if there is a specific data quality issue based on a user provided flag. Users can use the `list_distillates()` method to see which distillates are available:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "c3bb9a8e",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead>\n",
-       "<tr><th>uuid       </th><th>collection                                 </th><th>name  </th><th>repeats  </th><th>duplicate-times  </th><th>zeros  </th></tr>\n",
-       "</thead>\n",
-       "<tbody>\n",
-       "<tr><td>9464f51f...</td><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>x        </td><td>✓                </td><td>✓      </td></tr>\n",
-       "</tbody>\n",
-       "</table>"
-      ],
       "text/plain": [
-       "'<table>\\n<thead>\\n<tr><th>uuid       </th><th>collection                                 </th><th>name  </th><th>repeats  </th><th>duplicate-times  </th><th>zeros  </th></tr>\\n</thead>\\n<tbody>\\n<tr><td>9464f51f...</td><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>x        </td><td>✓                </td><td>✓      </td></tr>\\n</tbody>\\n</table>'"
+       "{'uuid': '4f8a9730-80e6-4378-948d-cb64a277f8f3',\n",
+       " 'collection': 'monitoring/generator1',\n",
+       " 'name': 'PhA_Cang',\n",
+       " 'repeats': True,\n",
+       " 'duplicate-times': True,\n",
+       " 'zeros': True}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# see which distillates are available\n",
-    "dq.list_distillates(notebook=True)"
+    "dq.list_distillates()"
    ]
   },
   {
@@ -125,12 +119,12 @@
    "id": "a72a0f80",
    "metadata": {},
    "source": [
-    "According to the table, this stream has `zeros` and `duplicate-times` distillates available, so let's see if we can find any events:"
+    "According to the output, this stream has `zeros`, `repeats`, and `duplicate-times` distillates available, so let's see if we can find any events:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "70b46454",
    "metadata": {},
    "outputs": [
@@ -140,13 +134,13 @@
        "True"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "dq.contains_any_event()"
+    "dq.contains_any_issue()"
    ]
   },
   {
@@ -167,19 +161,19 @@
     }
    ],
    "source": [
-    "dq.contains_event(\"zeros\")"
+    "dq.contains_issue(\"zeros\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "55e88edb",
+   "id": "2cfe8220",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "True"
+       "False"
       ]
      },
      "execution_count": 7,
@@ -188,23 +182,13 @@
     }
    ],
    "source": [
-    "dq.contains_event(\"duplicate-times\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9cf536b5",
-   "metadata": {},
-   "source": [
-    "It looks like this stream contains both zero values and duplicate times.\n",
-    "\n",
-    "We can also narrow our search to a specific time limit. You can see in the following example that this stream does not contain any zero values on July 16th:"
+    "dq.contains_issue(\"repeats\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "b5721cd7",
+   "id": "55e88edb",
    "metadata": {},
    "outputs": [
     {
@@ -219,9 +203,40 @@
     }
    ],
    "source": [
+    "dq.contains_issue(\"duplicate-times\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9cf536b5",
+   "metadata": {},
+   "source": [
+    "It looks like this stream contains zero values, but does not contain repeats or duplicate timestamps.\n",
+    "\n",
+    "We can also narrow our search to a specific time limit. You can see in the following example that this stream does not contain any zero values on July 16th:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b5721cd7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
     "start = \"2021-07-16 00:00:00.00\"\n",
     "end = \"2021-07-17 00:00:00.00\"\n",
-    "dq.contains_event(\"zeros\", start=start, end=end)"
+    "dq.contains_issue(\"zeros\", start=start, end=end)"
    ]
   },
   {
@@ -235,32 +250,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "66c2c8b9",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/michael.chestnut/projects/btrdbextras/btrdbextras/dq.py:97: UserWarning: Could not find distillates for stream 077d6745-e3ae-5795-b22d-1eb067abb360\n",
-      "  warnings.warn(f\"Could not find distillates for stream {str(self.uuid)}\")\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
        "<DQStreamSet (2 streams)>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "stream1 = db.stream_from_uuid(\"9464f51f-e05a-5db1-a965-3c339f748081\")\n",
-    "stream2 = db.stream_from_uuid(\"077d6745-e3ae-5795-b22d-1eb067abb360\")\n",
+    "stream1 = db.stream_from_uuid(\"4f8a9730-80e6-4378-948d-cb64a277f8f3\")\n",
+    "stream2 = db.stream_from_uuid(\"53daa83c-f5fb-4520-b2fe-82c144e3dbef\")\n",
     "dqss = DQStreamSet([stream1, stream2])\n",
     "dqss"
    ]
@@ -275,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "bacbbb52",
    "metadata": {},
    "outputs": [
@@ -284,19 +291,19 @@
       "text/html": [
        "<table>\n",
        "<thead>\n",
-       "<tr><th>Collection                                 </th><th>Name  </th><th>Unit  </th><th>UUID       </th><th style=\"text-align: right;\">  Version</th><th>Available Data Quality Info  </th></tr>\n",
+       "<tr><th>Collection           </th><th>Name    </th><th>Unit   </th><th>UUID       </th><th style=\"text-align: right;\">  Version</th><th>Available Data Quality Info    </th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "<tr><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>rand  </td><td>9464f51f...</td><td style=\"text-align: right;\">     1298</td><td>zeros, duplicate-times       </td></tr>\n",
-       "<tr><td>distiltest/f0bd-d75b-582b-b8e9-ac9cc9401755</td><td>rand  </td><td>rand  </td><td>077d6745...</td><td style=\"text-align: right;\">     1298</td><td>N/A                          </td></tr>\n",
+       "<tr><td>monitoring/generator1</td><td>PhA_Cang</td><td>Degrees</td><td>4f8a9730...</td><td style=\"text-align: right;\">     1357</td><td>repeats, zeros, duplicate-times</td></tr>\n",
+       "<tr><td>monitoring/generator2</td><td>PhA_Cang</td><td>Degrees</td><td>53daa83c...</td><td style=\"text-align: right;\">     1366</td><td>zeros, repeats, duplicate-times</td></tr>\n",
        "</tbody>\n",
        "</table>"
       ],
       "text/plain": [
-       "'<table>\\n<thead>\\n<tr><th>Collection                                 </th><th>Name  </th><th>Unit  </th><th>UUID       </th><th style=\"text-align: right;\">  Version</th><th>Available Data Quality Info  </th></tr>\\n</thead>\\n<tbody>\\n<tr><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>rand  </td><td>9464f51f...</td><td style=\"text-align: right;\">     1298</td><td>zeros, duplicate-times       </td></tr>\\n<tr><td>distiltest/f0bd-d75b-582b-b8e9-ac9cc9401755</td><td>rand  </td><td>rand  </td><td>077d6745...</td><td style=\"text-align: right;\">     1298</td><td>N/A                          </td></tr>\\n</tbody>\\n</table>'"
+       "'<table>\\n<thead>\\n<tr><th>Collection           </th><th>Name    </th><th>Unit   </th><th>UUID       </th><th style=\"text-align: right;\">  Version</th><th>Available Data Quality Info    </th></tr>\\n</thead>\\n<tbody>\\n<tr><td>monitoring/generator1</td><td>PhA_Cang</td><td>Degrees</td><td>4f8a9730...</td><td style=\"text-align: right;\">     1357</td><td>repeats, zeros, duplicate-times</td></tr>\\n<tr><td>monitoring/generator2</td><td>PhA_Cang</td><td>Degrees</td><td>53daa83c...</td><td style=\"text-align: right;\">     1366</td><td>zeros, repeats, duplicate-times</td></tr>\\n</tbody>\\n</table>'"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -315,34 +322,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "0d6a6710",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead>\n",
-       "<tr><th>uuid       </th><th>collection                                 </th><th>name  </th><th>repeats  </th><th>duplicate-times  </th><th>zeros  </th></tr>\n",
-       "</thead>\n",
-       "<tbody>\n",
-       "<tr><td>9464f51f...</td><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>x        </td><td>✓                </td><td>✓      </td></tr>\n",
-       "<tr><td>077d6745...</td><td>distiltest/f0bd-d75b-582b-b8e9-ac9cc9401755</td><td>rand  </td><td>x        </td><td>x                </td><td>x      </td></tr>\n",
-       "</tbody>\n",
-       "</table>"
-      ],
       "text/plain": [
-       "'<table>\\n<thead>\\n<tr><th>uuid       </th><th>collection                                 </th><th>name  </th><th>repeats  </th><th>duplicate-times  </th><th>zeros  </th></tr>\\n</thead>\\n<tbody>\\n<tr><td>9464f51f...</td><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>x        </td><td>✓                </td><td>✓      </td></tr>\\n<tr><td>077d6745...</td><td>distiltest/f0bd-d75b-582b-b8e9-ac9cc9401755</td><td>rand  </td><td>x        </td><td>x                </td><td>x      </td></tr>\\n</tbody>\\n</table>'"
+       "[{'uuid': '4f8a9730-80e6-4378-948d-cb64a277f8f3',\n",
+       "  'collection': 'monitoring/generator1',\n",
+       "  'name': 'PhA_Cang',\n",
+       "  'repeats': True,\n",
+       "  'duplicate-times': True,\n",
+       "  'zeros': True},\n",
+       " {'uuid': '53daa83c-f5fb-4520-b2fe-82c144e3dbef',\n",
+       "  'collection': 'monitoring/generator2',\n",
+       "  'name': 'PhA_Cang',\n",
+       "  'repeats': True,\n",
+       "  'duplicate-times': True,\n",
+       "  'zeros': True}]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "dqss.list_distillates(notebook=True)"
+    "dqss.list_distillates()"
    ]
   },
   {
@@ -355,59 +362,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "0ca2062a",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'9464f51f-e05a-5db1-a965-3c339f748081': True,\n",
-       " '077d6745-e3ae-5795-b22d-1eb067abb360': None}"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dqss.contains_any_event()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "335c7841",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'9464f51f-e05a-5db1-a965-3c339f748081': True,\n",
-       " '077d6745-e3ae-5795-b22d-1eb067abb360': None}"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dqss.contains_event(\"duplicate-times\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "58310f50",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'9464f51f-e05a-5db1-a965-3c339f748081': True,\n",
-       " '077d6745-e3ae-5795-b22d-1eb067abb360': None}"
+       "{'4f8a9730-80e6-4378-948d-cb64a277f8f3': True,\n",
+       " '53daa83c-f5fb-4520-b2fe-82c144e3dbef': True}"
       ]
      },
      "execution_count": 14,
@@ -416,7 +379,51 @@
     }
    ],
    "source": [
-    "dqss.contains_event(\"zeros\")"
+    "dqss.contains_any_issue()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "335c7841",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'4f8a9730-80e6-4378-948d-cb64a277f8f3': False,\n",
+       " '53daa83c-f5fb-4520-b2fe-82c144e3dbef': False}"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dqss.contains_issue(\"duplicate-times\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "58310f50",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'4f8a9730-80e6-4378-948d-cb64a277f8f3': True,\n",
+       " '53daa83c-f5fb-4520-b2fe-82c144e3dbef': True}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dqss.contains_issue(\"zeros\")"
    ]
   },
   {

--- a/notebooks/dq_demo.ipynb
+++ b/notebooks/dq_demo.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Data Quality API\n",
-    "The purpose of this notebook is to demonstrate how to use the Data Quality API to access a BTrDB Stream's distillates and identify data quality issues"
+    "The purpose of this notebook is to demonstrate a POC Data Quality API that can be used to access a BTrDB stream's distillate streams and use them to identify data quality events."
    ]
   },
   {
@@ -48,7 +48,7 @@
    "id": "3a2321a8",
    "metadata": {},
    "source": [
-    "First we will see how to work with a single BTrDB Stream. `DQStream` subsets `Stream`, and can be instantiated by simply passing in a BTrDB `Stream` object."
+    "First we will see how to work with a single BTrDB Stream. `DQStream` inherits from `Stream`, and can be instantiated by simply passing in a BTrDB `Stream` object."
    ]
   },
   {
@@ -73,25 +73,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88454b01",
+   "id": "526040e1",
    "metadata": {},
    "source": [
-    "`DQStream` has all of the same attributes and methods as `Stream`, but it has an additional attribute `distillates`, which refers to a list of all of the distillate streams that have been derived from this source stream. We can use these distillates to identify specific data quality concerns."
+    "`DQStream` has all of the same attributes and methods as `Stream`, as well as an additional attribute, `distillates`. Distillates is a list of all of the distillate streams that have been derived from the source stream. Each distillate is a sparse stream that contains only values of 1 at timestamps where a specific data quality issue has occurred. We can use these distillates to identify specific data quality concerns for a given `Stream`."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "46f73253",
+   "id": "3f4e2917",
    "metadata": {},
    "source": [
     "## Detecting Events\n",
-    "We can use the `DQStream` to identify if the original `Stream` contains data quality issues. There are two methods for this: `contains_any_event()`, which reports if there are _any_ data quality concerns within the stream, as well as `contains_event()`, which reports if there is a specific data quality issue based on a user provided flag. Users can use the `list_distillates()` method to see which distillates are available"
+    "We can use the `DQStream` to identify if the original `Stream` contains data quality issues. There are two methods for this: `contains_any_event()`, which reports if there are _any_ data quality concerns within the stream, as well as `contains_event()`, which reports if there is a specific data quality issue based on a user provided flag. Users can use the `list_distillates()` method to see which distillates are available:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "a7abb3bd",
+   "id": "c3bb9a8e",
    "metadata": {},
    "outputs": [
     {
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4cae5a7e",
+   "id": "a72a0f80",
    "metadata": {},
    "source": [
     "According to the table, this stream has `zeros` and `duplicate-times` distillates available, so let's see if we can find any events:"
@@ -131,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "4ebe2867",
+   "id": "70b46454",
    "metadata": {},
    "outputs": [
     {
@@ -152,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "f849be7c",
+   "id": "9014c0cb",
    "metadata": {},
    "outputs": [
     {
@@ -171,19 +171,40 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "55e88edb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dq.contains_event(\"duplicate-times\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "52be22ea",
+   "id": "9cf536b5",
    "metadata": {},
    "source": [
-    "It looks like this stream contains some zero values.\n",
+    "It looks like this stream contains both zero values and duplicate times.\n",
     "\n",
     "We can also narrow our search to a specific time limit. You can see in the following example that this stream does not contain any zero values on July 16th:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "9627bb87",
+   "execution_count": 8,
+   "id": "b5721cd7",
    "metadata": {},
    "outputs": [
     {
@@ -192,7 +213,7 @@
        "False"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -205,7 +226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1c5477d",
+   "id": "4df83597",
    "metadata": {},
    "source": [
     "## Working with StreamSets\n",
@@ -214,15 +235,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "845f3d91",
+   "execution_count": 9,
+   "id": "66c2c8b9",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/michael.chestnut/projects/btrdbextras/btrdbextras/dq.py:92: UserWarning: Could not find distillates for stream 077d6745-e3ae-5795-b22d-1eb067abb360\n",
+      "/Users/michael.chestnut/projects/btrdbextras/btrdbextras/dq.py:97: UserWarning: Could not find distillates for stream 077d6745-e3ae-5795-b22d-1eb067abb360\n",
       "  warnings.warn(f\"Could not find distillates for stream {str(self.uuid)}\")\n"
      ]
     },
@@ -232,7 +253,7 @@
        "<DQStreamSet (2 streams)>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -246,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4683eab",
+   "id": "d465edd9",
    "metadata": {},
    "source": [
     "`DQStreamSet` has a `describe()` method that allows us to see metadata of the underlying `Streams`:"
@@ -254,8 +275,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "1acbaad5",
+   "execution_count": 10,
+   "id": "bacbbb52",
    "metadata": {},
    "outputs": [
     {
@@ -266,16 +287,16 @@
        "<tr><th>Collection                                 </th><th>Name  </th><th>Unit  </th><th>UUID       </th><th style=\"text-align: right;\">  Version</th><th>Available Data Quality Info  </th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "<tr><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>rand  </td><td>9464f51f...</td><td style=\"text-align: right;\">     1072</td><td>zeros, duplicate-times       </td></tr>\n",
-       "<tr><td>distiltest/f0bd-d75b-582b-b8e9-ac9cc9401755</td><td>rand  </td><td>rand  </td><td>077d6745...</td><td style=\"text-align: right;\">     1072</td><td>N/A                          </td></tr>\n",
+       "<tr><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>rand  </td><td>9464f51f...</td><td style=\"text-align: right;\">     1298</td><td>zeros, duplicate-times       </td></tr>\n",
+       "<tr><td>distiltest/f0bd-d75b-582b-b8e9-ac9cc9401755</td><td>rand  </td><td>rand  </td><td>077d6745...</td><td style=\"text-align: right;\">     1298</td><td>N/A                          </td></tr>\n",
        "</tbody>\n",
        "</table>"
       ],
       "text/plain": [
-       "'<table>\\n<thead>\\n<tr><th>Collection                                 </th><th>Name  </th><th>Unit  </th><th>UUID       </th><th style=\"text-align: right;\">  Version</th><th>Available Data Quality Info  </th></tr>\\n</thead>\\n<tbody>\\n<tr><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>rand  </td><td>9464f51f...</td><td style=\"text-align: right;\">     1072</td><td>zeros, duplicate-times       </td></tr>\\n<tr><td>distiltest/f0bd-d75b-582b-b8e9-ac9cc9401755</td><td>rand  </td><td>rand  </td><td>077d6745...</td><td style=\"text-align: right;\">     1072</td><td>N/A                          </td></tr>\\n</tbody>\\n</table>'"
+       "'<table>\\n<thead>\\n<tr><th>Collection                                 </th><th>Name  </th><th>Unit  </th><th>UUID       </th><th style=\"text-align: right;\">  Version</th><th>Available Data Quality Info  </th></tr>\\n</thead>\\n<tbody>\\n<tr><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>rand  </td><td>9464f51f...</td><td style=\"text-align: right;\">     1298</td><td>zeros, duplicate-times       </td></tr>\\n<tr><td>distiltest/f0bd-d75b-582b-b8e9-ac9cc9401755</td><td>rand  </td><td>rand  </td><td>077d6745...</td><td style=\"text-align: right;\">     1298</td><td>N/A                          </td></tr>\\n</tbody>\\n</table>'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -286,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1b62fa3",
+   "id": "7e0e44e3",
    "metadata": {},
    "source": [
     "We can also peak at the underlying `Streams` and see which distillates they have available. Note that the second `Stream` does not have any distillates."
@@ -294,8 +315,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "72d86d4b",
+   "execution_count": 11,
+   "id": "0d6a6710",
    "metadata": {},
    "outputs": [
     {
@@ -315,7 +336,7 @@
        "'<table>\\n<thead>\\n<tr><th>uuid       </th><th>collection                                 </th><th>name  </th><th>repeats  </th><th>duplicate-times  </th><th>zeros  </th></tr>\\n</thead>\\n<tbody>\\n<tr><td>9464f51f...</td><td>distiltest/a574-5a32-518b-b4e9-c9c86144107a</td><td>rand  </td><td>x        </td><td>✓                </td><td>✓      </td></tr>\\n<tr><td>077d6745...</td><td>distiltest/f0bd-d75b-582b-b8e9-ac9cc9401755</td><td>rand  </td><td>x        </td><td>x                </td><td>x      </td></tr>\\n</tbody>\\n</table>'"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -326,7 +347,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6cbdba9c",
+   "id": "c6c0426a",
    "metadata": {},
    "source": [
     "We can also see if the `Streams` within a `DQStreamSet` contain any events. The output of these methods is a `dict` with each `Stream` UUID as the key and a bool value indicating whether an event was found. Note that `None` will be returned as the value if the `DQStream` does not contain a certain distillate."
@@ -334,8 +355,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "672d6a78",
+   "execution_count": 12,
+   "id": "0ca2062a",
    "metadata": {},
    "outputs": [
     {
@@ -345,7 +366,7 @@
        " '077d6745-e3ae-5795-b22d-1eb067abb360': None}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -356,8 +377,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "3f9bf9b3",
+   "execution_count": 13,
+   "id": "335c7841",
    "metadata": {},
    "outputs": [
     {
@@ -367,7 +388,7 @@
        " '077d6745-e3ae-5795-b22d-1eb067abb360': None}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -378,8 +399,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "ffe929fd",
+   "execution_count": 14,
+   "id": "58310f50",
    "metadata": {},
    "outputs": [
     {
@@ -389,7 +410,7 @@
        " '077d6745-e3ae-5795-b22d-1eb067abb360': None}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -400,7 +421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cbee33c1",
+   "id": "3934080a",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -411,7 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af8c65e3",
+   "id": "0c5e75d8",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,11 @@ grpcio-tools>=1.16.1
 # Serialization helpers
 dill==0.3.2
 
+# BTrDB
+btrdb>=5.11.6
+
+# Utilities and helpers
+tabulate==0.8.9
+
 # Readthedocs
 sphinx_glpi_theme


### PR DESCRIPTION
This PR fulfills [this ticket](https://app.clubhouse.io/pingthings-ws/story/14371/develop-poc-python-data-quality-api) and adds a data quality API POC.

The idea behind the data quality API is to provide a way for users to easily group input streams with their data quality distillates and use these distillates to identify data quality concerns. For now the data quality checks just return True/False, indicating whether or not there is any data quality event (or a specific event) for a Stream/StreamSet during a given time.

Here is a [notebook](https://github.com/PingThingsIO/btrdbextras/blob/dq/notebooks/dq_demo.ipynb) that shows how the API can be used. Note that is meant to be a starting point, we will definitely want to add more functionality later on!

It's important to note that these API requires the following metadata to work properly:
* distillers will need to follow a certain naming convention when creating output streams for distillate identification to work properly.
* distillers will need to put `source_uuid` annotation in output streams so they can be correctly matched with their source streams.